### PR TITLE
feat: apply minimal apple-inspired styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,68 +6,70 @@
 <title>Dashboard de Máquinas — Jornada 06:00–16:00</title>
 <style>
   :root{
-    --bg:#fff;
+    --bg:#f5f5f7;
     --panel:#fff;
-    --muted:#ff;
-    --text:#000;
-    --ok:#000;
-    --bad:#000;
-    --warn:#000;
-    --line:#1f2430;
-    --chip-bg:#fff;
-    --chip-br:#fff;
-    --accent:#4da3ff;
+    --muted:#6e6e73;
+    --text:#1d1d1f;
+    --ok:#34c759;
+    --bad:#ff3b30;
+    --warn:#ff9f0a;
+    --line:#d2d2d7;
+    --chip-bg:#f5f5f7;
+    --chip-br:#e5e5ea;
+    --accent:#0071e3;
+    --shadow:0 18px 44px rgba(0,0,0,0.08);
   }
   *{box-sizing:border-box}
   html,body{height:100%}
   body{
     margin:0;
-    font-family: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Helvetica,Arial;
-    background:#fff;
+    font-family:"SF Pro Display","SF Pro Text",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    background:var(--bg);
     color:var(--text);
+    -webkit-font-smoothing:antialiased;
   }
-  .wrap{max-width:1200px;margin-inline:auto;padding:28px 18px 40px}
-  header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:18px}
+  .wrap{max-width:1080px;margin-inline:auto;padding:40px 24px 64px}
+  header{display:flex;align-items:flex-start;justify-content:space-between;gap:20px;margin-bottom:28px}
   .title{display:flex;flex-direction:column;gap:6px}
-  .title h1{margin:0;font-size:clamp(18px,2.2vw,24px);font-weight:650;letter-spacing:.3px}
-  .subtitle{color:var(--muted);font-size:14px}
-  .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}
-  .chip{display:inline-flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--chip-br);border-radius:12px;background:var(--chip-bg);color:var(--muted);font-size:12.5px}
-  .dot{width:8px;height:8px;border-radius:999px;background:var(--muted);box-shadow:0 0 0 1px #0003 inset}
+  .title h1{margin:0;font-size:clamp(20px,2.6vw,28px);font-weight:650;letter-spacing:.2px}
+  .subtitle{color:var(--muted);font-size:14px;line-height:1.6}
+  .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+  .chip{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border:1px solid var(--chip-br);border-radius:999px;background:var(--chip-bg);color:var(--muted);font-size:12.5px}
+  .dot{width:8px;height:8px;border-radius:999px;background:var(--muted);box-shadow:0 0 0 1px rgba(0,0,0,0.06) inset}
   .dot.ok{background:var(--ok)}
   .dot.bad{background:var(--bad)}
   .dot.warn{background:var(--warn)}
   .controls{display:flex;flex-wrap:wrap;gap:10px}
-  button,.ghost{appearance:none;border:1px solid #2a3244;background:#101521;color:var(--text);padding:10px 12px;border-radius:10px;font-weight:600;cursor:pointer;transition:.18s transform ease,.18s background ease,.18s border-color ease}
-  button:hover{transform:translateY(-1px);border-color:#334059;background:#111827}
-  .ghost{background:transparent}
-  .panel{background:var(--panel);border:1px solid #fff;border-radius:16px;overflow:hidden;box-shadow:0 10px 28px rgba(0,0,0,.25)}
+  button,.ghost{appearance:none;border:1px solid var(--chip-br);background:#fff;color:var(--text);padding:10px 16px;border-radius:999px;font-weight:600;cursor:pointer;transition:.18s transform ease,.18s background ease,.18s border-color ease;box-shadow:0 6px 12px rgba(0,0,0,0.04)}
+  button:hover{transform:translateY(-1px);border-color:#c7c7cc;background:#f2f2f7}
+  .ghost{background:var(--bg)}
+  .panel{background:var(--panel);border:1px solid #e5e5ea;border-radius:28px;overflow:hidden;box-shadow:var(--shadow)}
   /* Tabla */
   .tbl{width:100%;border-collapse:separate;border-spacing:0}
   thead th{
-    position:sticky;top:0;z-index:3;background:linear-gradient(180deg,#141a24 0%,#141821 100%);
-    color:#cfd7ea;border-bottom:1px solid var(--line);padding:14px 12px;font-size:13px;
-    text-transform:uppercase;letter-spacing:.06em;font-weight:700;
+    position:sticky;top:0;z-index:3;background:#fff;
+    color:var(--muted);border-bottom:1px solid var(--line);padding:16px 14px;font-size:12.5px;
+    text-transform:uppercase;letter-spacing:.08em;font-weight:600;
   }
-  thead .sub{font-size:12px;text-transform:none;letter-spacing:0;color:#aab3c9}
-  tbody td{padding:12px;border-bottom:1px dashed #20283a;font-size:14.5px;color:#dfe6f7}
-  tbody tr:nth-child(odd){background:rgba(255,255,255,0.01)}
-  tbody tr:hover{background:#fff}
+  thead .sub{font-size:12px;text-transform:none;letter-spacing:0;color:var(--muted);margin-top:2px;font-weight:500}
+  tbody td{padding:16px 14px;border-bottom:1px solid rgba(210,210,215,0.6);font-size:14.5px;color:#3a3a3c}
+  tbody tr:nth-child(odd){background:rgba(0,0,0,0.015)}
+  tbody tr:hover{background:#f2f2f7}
   .time{
-    position:sticky;left:0;background:linear-gradient(90deg,#141821 70%,rgba(20,24,33,0));
-    z-index:2;font-weight:700;color:#c9d3ea;border-right:1px solid var(--line)
+    position:sticky;left:0;background:linear-gradient(90deg,#fff 75%,rgba(255,255,255,0));
+    z-index:2;font-weight:600;color:var(--text);border-right:1px solid var(--line)
   }
   .status{
-    display:inline-flex;align-items:center;gap:8px;font-weight:650;padding:6px 10px;border-radius:999px;
-    background:#0f141e;border:1px solid #273045
+    display:inline-flex;align-items:center;gap:8px;font-weight:600;padding:6px 12px;border-radius:999px;
+    background:#f5f5f7;border:1px solid var(--chip-br);color:var(--text);
   }
-  .status.ok{color:#ccffe1;border-color:#1d3c2c;background:rgba(24,201,100,.10)}
-  .status.bad{color:#ffe1e1;border-color:#402126;background:rgba(255,77,79,.10)}
-  .status.warn{color:#fff5dc;border-color:#3d2d12;background:rgba(255,191,71,.12)}
-  .cond{color:#cdd6ee}
-  .mini{display:flex;gap:10px;align-items:center;color:var(--muted);font-size:12px}
-  .pill{padding:.2rem .55rem;border-radius:999px;border:1px solid var(--chip-br);color:#c9d3ea;background:#0f141e;font-size:12px}
-  .now{outline:2px solid var(--accent);outline-offset:-2px;background:#10182a !important}
+  .status.ok{color:#1f7a39;border-color:rgba(52,199,89,0.35);background:rgba(52,199,89,0.12)}
+  .status.bad{color:#a22022;border-color:rgba(255,59,48,0.35);background:rgba(255,59,48,0.12)}
+  .status.warn{color:#ad5f00;border-color:rgba(255,159,10,0.35);background:rgba(255,159,10,0.16)}
+  .cond{color:#515154;line-height:1.5}
+  .mini{display:flex;gap:12px;align-items:center;color:var(--muted);font-size:12.5px;margin-top:20px}
+  .pill{padding:.35rem .8rem;border-radius:999px;border:1px solid var(--chip-br);color:var(--text);background:#fff;font-size:12.5px;box-shadow:0 6px 12px rgba(0,0,0,0.05)}
+  .now{box-shadow:inset 0 0 0 2px var(--accent);background:rgba(0,113,227,0.08)!important}
   @media (max-width: 900px){
     thead .hide-sm, tbody .hide-sm{display:none}
     .subtitle{max-width:500px}


### PR DESCRIPTION
## Summary
- refresh the dashboard with a light, Apple-inspired palette and SF Pro typography
- soften components with rounded panels, pill buttons, and subtle status chips
- adjust table hover and "now" highlighting to match the minimal aesthetic

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68e3d5cd4c388323a90fa5961c0172c8