### PR TITLE
Provide selectable design proposals for machine dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,84 +3,239 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Dashboard de Máquinas — Jornada 06:00–16:00</title>
+<title>Dashboard de Máquinas — Jornada 06:00–12:00</title>
 <style>
   :root{
-    --bg:#fff;
-    --panel:#fff;
-    --muted:#ff;
-    --text:#000;
-    --ok:#000;
-    --bad:#000;
-    --warn:#000;
-    --line:#1f2430;
-    --chip-bg:#fff;
-    --chip-br:#fff;
-    --accent:#4da3ff;
+    font-size:16px;
   }
   *{box-sizing:border-box}
   html,body{height:100%}
   body{
     margin:0;
-    font-family: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Helvetica,Arial;
-    background:#fff;
-    color:var(--text);
+    font-family:var(--font, "SF Pro Display","SF Pro Text",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif);
+    background:var(--bg,#f5f5f7);
+    color:var(--text,#1d1d1f);
+    -webkit-font-smoothing:antialiased;
+    transition:background .4s ease,color .4s ease;
   }
-  .wrap{max-width:1200px;margin-inline:auto;padding:28px 18px 40px}
-  header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:18px}
+  body.theme-aurora{
+    --font: "SF Pro Display","SF Pro Text",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    --bg:#f5f5f7;
+    --panel:#fff;
+    --panel-border:1px solid #e5e5ea;
+    --panel-radius:22px;
+    --muted:#6e6e73;
+    --text:#1d1d1f;
+    --line:rgba(210,210,215,0.7);
+    --divider:1.5px solid rgba(210,210,215,0.8);
+    --chip-bg:#f5f5f7;
+    --chip-br:#e5e5ea;
+    --chip-text:#6e6e73;
+    --accent:#0071e3;
+    --shadow:0 18px 44px rgba(0,0,0,0.08);
+    --row-alt:rgba(0,0,0,0.015);
+    --row-hover:#f7f7fb;
+    --header-bg:#fff;
+    --head-text:#6e6e73;
+    --cell-text:#3a3a3c;
+    --cond-text:#515154;
+    --status-neutral-bg:var(--chip-bg);
+    --status-neutral-border:rgba(210,210,215,0.7);
+    --status-shadow:inset 0 -2px 6px rgba(0,0,0,0.12);
+    --status-ok-bg:linear-gradient(135deg,rgba(52,199,89,0.65),rgba(88,224,118,0.95));
+    --status-ok-border:rgba(52,199,89,0.45);
+    --status-warn-bg:linear-gradient(135deg,rgba(255,204,0,0.65),rgba(255,214,40,0.95));
+    --status-warn-border:rgba(255,204,0,0.5);
+    --status-bad-bg:linear-gradient(135deg,rgba(255,59,48,0.75),rgba(255,105,97,0.95));
+    --status-bad-border:rgba(255,59,48,0.5);
+    --status-future-bg:repeating-linear-gradient(135deg,rgba(210,210,215,0.4) 0,rgba(210,210,215,0.4) 6px,rgba(255,255,255,0.6) 6px,rgba(255,255,255,0.6) 12px);
+    --status-future-border:rgba(210,210,215,0.6);
+    --chip-bad-bg:rgba(255,59,48,0.14);
+    --chip-bad-border:rgba(255,59,48,0.35);
+    --chip-bad-text:#a22022;
+    --chip-warn-bg:rgba(255,204,0,0.14);
+    --chip-warn-border:rgba(255,204,0,0.35);
+    --chip-warn-text:#ad5f00;
+    --pill-bg:#fff;
+    --pill-border:1px solid var(--chip-br);
+    --pill-shadow:0 6px 12px rgba(0,0,0,0.05);
+    --now-bg:rgba(0,113,227,0.08);
+    --now-outline:var(--accent);
+    --time-gradient:linear-gradient(90deg,var(--header-bg) 75%,rgba(255,255,255,0));
+    color-scheme:light;
+  }
+  body.theme-blueprint{
+    --font:"Inter","SF Pro Text",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+    --bg:radial-gradient(circle at top,#101b33 0%,#050b18 55%,#02040a 100%);
+    --panel:rgba(8,17,33,0.76);
+    --panel-border:1px solid rgba(104,189,255,0.22);
+    --panel-radius:28px;
+    --muted:#9fb4d8;
+    --text:#f5f9ff;
+    --line:rgba(68,112,180,0.38);
+    --divider:1.5px solid rgba(90,139,214,0.5);
+    --chip-bg:rgba(12,32,61,0.85);
+    --chip-br:rgba(117,168,236,0.3);
+    --chip-text:#d1e2ff;
+    --accent:#5bc0ff;
+    --shadow:0 40px 80px rgba(2,6,13,0.75);
+    --row-alt:rgba(20,48,94,0.35);
+    --row-hover:rgba(56,106,173,0.45);
+    --header-bg:rgba(8,17,33,0.9);
+    --head-text:#c5d7ff;
+    --cell-text:#e2efff;
+    --cond-text:#d3e4ff;
+    --status-neutral-bg:rgba(20,48,94,0.6);
+    --status-neutral-border:rgba(86,137,204,0.5);
+    --status-shadow:inset 0 0 12px rgba(0,0,0,0.35);
+    --status-ok-bg:linear-gradient(135deg,rgba(73,243,177,0.6),rgba(35,186,145,0.95));
+    --status-ok-border:rgba(111,255,210,0.7);
+    --status-warn-bg:linear-gradient(135deg,rgba(255,214,126,0.6),rgba(255,175,32,0.92));
+    --status-warn-border:rgba(255,214,126,0.75);
+    --status-bad-bg:linear-gradient(135deg,rgba(255,98,132,0.75),rgba(222,44,92,0.95));
+    --status-bad-border:rgba(255,125,157,0.85);
+    --status-future-bg:repeating-linear-gradient(135deg,rgba(74,110,184,0.6) 0,rgba(74,110,184,0.6) 8px,rgba(8,17,33,0.3) 8px,rgba(8,17,33,0.3) 16px);
+    --status-future-border:rgba(104,189,255,0.4);
+    --chip-bad-bg:rgba(255,118,118,0.28);
+    --chip-bad-border:rgba(255,141,170,0.6);
+    --chip-bad-text:#ffcfdd;
+    --chip-warn-bg:rgba(255,214,126,0.22);
+    --chip-warn-border:rgba(255,214,126,0.55);
+    --chip-warn-text:#ffe9c2;
+    --pill-bg:rgba(12,32,61,0.9);
+    --pill-border:1px solid rgba(104,189,255,0.4);
+    --pill-shadow:0 12px 30px rgba(2,8,18,0.6);
+    --now-bg:rgba(91,192,255,0.18);
+    --now-outline:#5bc0ff;
+    --time-gradient:linear-gradient(90deg,rgba(8,17,33,0.96) 72%,rgba(8,17,33,0));
+    color-scheme:dark;
+    background-attachment:fixed;
+  }
+  body.theme-blueprint .panel{backdrop-filter:blur(22px);}
+  body.theme-blueprint .theme-btn{color:#d4e6ff;}
+  body.theme-blueprint .theme-btn.active{box-shadow:0 18px 40px rgba(91,192,255,0.25);}
+  body.theme-blueprint .title h1{font-weight:650;letter-spacing:.4px;}
+  body.theme-atlas{
+    --font:"Neue Haas Grotesk Display Pro","Helvetica Neue",Helvetica,Arial,sans-serif;
+    --bg:#fbf8f3;
+    --panel:#fff9f0;
+    --panel-border:1px solid rgba(194,171,136,0.45);
+    --panel-radius:18px;
+    --muted:#8c7962;
+    --text:#2e2416;
+    --line:rgba(198,170,130,0.5);
+    --divider:1px dashed rgba(178,151,107,0.7);
+    --chip-bg:#fff3df;
+    --chip-br:rgba(224,189,137,0.6);
+    --chip-text:#8c7962;
+    --accent:#d0843e;
+    --shadow:0 24px 60px rgba(158,126,90,0.28);
+    --row-alt:rgba(255,239,214,0.55);
+    --row-hover:rgba(255,232,196,0.8);
+    --header-bg:#fff4e2;
+    --head-text:#9d8158;
+    --cell-text:#47341b;
+    --cond-text:#5c4121;
+    --status-neutral-bg:#fff0d8;
+    --status-neutral-border:rgba(208,132,62,0.35);
+    --status-shadow:inset 0 -2px 8px rgba(208,132,62,0.15);
+    --status-ok-bg:linear-gradient(135deg,rgba(160,217,102,0.75),rgba(117,187,68,0.95));
+    --status-ok-border:rgba(148,203,86,0.75);
+    --status-warn-bg:linear-gradient(135deg,rgba(255,207,96,0.85),rgba(232,158,34,0.95));
+    --status-warn-border:rgba(232,158,34,0.8);
+    --status-bad-bg:linear-gradient(135deg,rgba(214,87,57,0.75),rgba(160,38,12,0.95));
+    --status-bad-border:rgba(214,87,57,0.7);
+    --status-future-bg:repeating-linear-gradient(135deg,rgba(229,201,160,0.6) 0,rgba(229,201,160,0.6) 8px,rgba(255,250,242,0.6) 8px,rgba(255,250,242,0.6) 16px);
+    --status-future-border:rgba(208,132,62,0.45);
+    --chip-bad-bg:rgba(214,87,57,0.18);
+    --chip-bad-border:rgba(214,87,57,0.35);
+    --chip-bad-text:#752414;
+    --chip-warn-bg:rgba(232,158,34,0.18);
+    --chip-warn-border:rgba(232,158,34,0.4);
+    --chip-warn-text:#7b470a;
+    --pill-bg:#fff3df;
+    --pill-border:1px solid rgba(224,189,137,0.55);
+    --pill-shadow:0 10px 28px rgba(208,132,62,0.18);
+    --now-bg:rgba(208,132,62,0.14);
+    --now-outline:#d0843e;
+    --time-gradient:linear-gradient(90deg,rgba(255,244,226,0.96) 70%,rgba(251,248,243,0));
+    color-scheme:light;
+  }
+  .wrap{max-width:min(1400px,98vw);margin-inline:auto;padding:42px 8px 72px;display:flex;flex-direction:column;gap:28px}
+  header{display:flex;align-items:flex-start;justify-content:space-between;gap:20px}
   .title{display:flex;flex-direction:column;gap:6px}
-  .title h1{margin:0;font-size:clamp(18px,2.2vw,24px);font-weight:650;letter-spacing:.3px}
-  .subtitle{color:var(--muted);font-size:14px}
-  .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}
-  .chip{display:inline-flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--chip-br);border-radius:12px;background:var(--chip-bg);color:var(--muted);font-size:12.5px}
-  .dot{width:8px;height:8px;border-radius:999px;background:var(--muted);box-shadow:0 0 0 1px #0003 inset}
-  .dot.ok{background:var(--ok)}
-  .dot.bad{background:var(--bad)}
-  .dot.warn{background:var(--warn)}
+  .title h1{margin:0;font-size:clamp(20px,2.6vw,30px);font-weight:650;letter-spacing:.2px;color:var(--text)}
+  .subtitle{color:var(--muted);font-size:14px;line-height:1.6}
+  .chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+  .chip{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;border:1px solid var(--chip-br);border-radius:999px;background:var(--chip-bg);color:var(--chip-text);font-size:12.5px;transition:background .3s ease,color .3s ease,border-color .3s ease}
+  .dot{width:8px;height:8px;border-radius:999px;background:var(--muted);box-shadow:0 0 0 1px rgba(0,0,0,0.06) inset}
+  .dot.ok{background:var(--status-ok-border)}
+  .dot.bad{background:var(--status-bad-border)}
+  .dot.warn{background:var(--status-warn-border)}
   .controls{display:flex;flex-wrap:wrap;gap:10px}
-  button,.ghost{appearance:none;border:1px solid #2a3244;background:#101521;color:var(--text);padding:10px 12px;border-radius:10px;font-weight:600;cursor:pointer;transition:.18s transform ease,.18s background ease,.18s border-color ease}
-  button:hover{transform:translateY(-1px);border-color:#334059;background:#111827}
-  .ghost{background:transparent}
-  .panel{background:var(--panel);border:1px solid #fff;border-radius:16px;overflow:hidden;box-shadow:0 10px 28px rgba(0,0,0,.25)}
-  /* Tabla */
+  .action-btn{appearance:none;border:1px solid var(--chip-br);background:var(--panel);color:var(--text);padding:10px 16px;border-radius:999px;font-weight:600;cursor:pointer;transition:.18s transform ease,.18s background ease,.18s border-color ease;box-shadow:0 6px 12px rgba(0,0,0,0.04)}
+  .action-btn:hover{transform:translateY(-1px);border-color:rgba(0,0,0,0.12);background:rgba(255,255,255,0.8)}
+  .action-btn.ghost{background:transparent}
+  body.theme-blueprint .action-btn{background:rgba(16,36,66,0.95);border-color:rgba(91,192,255,0.4);color:#e2efff;box-shadow:0 12px 28px rgba(2,8,18,0.45)}
+  body.theme-blueprint .action-btn:hover{background:rgba(19,48,92,0.95);border-color:rgba(91,192,255,0.65)}
+  body.theme-blueprint .action-btn.ghost{background:rgba(14,32,62,0.4)}
+  body.theme-atlas .action-btn{background:#fff;border-color:rgba(208,132,62,0.3);color:#5c4121;box-shadow:0 10px 24px rgba(208,132,62,0.18)}
+  body.theme-atlas .action-btn:hover{background:#fff7ec;border-color:rgba(208,132,62,0.45)}
+  .theme-explorer{background:var(--panel);border-radius:calc(var(--panel-radius) - 6px);border:var(--panel-border);box-shadow:var(--shadow);padding:28px 28px 32px;display:grid;gap:22px}
+  .theme-explorer h2{margin:0;font-size:clamp(18px,2vw,24px);font-weight:640;color:var(--text)}
+  .theme-explorer p{margin:0;color:var(--muted);line-height:1.6;font-size:14px;max-width:560px}
+  .theme-picker{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+  .theme-btn{position:relative;display:flex;flex-direction:column;align-items:flex-start;gap:6px;padding:16px 18px;border-radius:18px;border:1px solid rgba(0,0,0,0.05);background:rgba(255,255,255,0.66);cursor:pointer;font:inherit;color:var(--text);text-align:left;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease,background .3s ease;outline:none}
+  .theme-btn .theme-name{font-size:15px;font-weight:650}
+  .theme-btn .theme-desc{font-size:12.5px;color:var(--muted)}
+  .theme-btn::after{content:"";position:absolute;inset:6px;border-radius:14px;border:1px dashed transparent;transition:border-color .3s ease}
+  .theme-btn:hover{transform:translateY(-2px);box-shadow:0 16px 26px rgba(0,0,0,0.12)}
+  .theme-btn.active{background:var(--now-bg);border-color:var(--now-outline);box-shadow:0 20px 36px rgba(0,0,0,0.14)}
+  .theme-btn.active::after{border-color:var(--now-outline)}
+  body.theme-blueprint .theme-btn{background:rgba(14,32,62,0.66);border:1px solid rgba(104,189,255,0.25)}
+  body.theme-blueprint .theme-btn .theme-desc{color:rgba(211,228,255,0.75)}
+  body.theme-atlas .theme-btn{background:#fff4e2;border-color:rgba(208,132,62,0.25)}
+  .panel{background:var(--panel);border:var(--panel-border);border-radius:var(--panel-radius);overflow:hidden;box-shadow:var(--shadow);transition:background .4s ease,border-color .4s ease,box-shadow .4s ease}
   .tbl{width:100%;border-collapse:separate;border-spacing:0}
-  thead th{
-    position:sticky;top:0;z-index:3;background:linear-gradient(180deg,#141a24 0%,#141821 100%);
-    color:#cfd7ea;border-bottom:1px solid var(--line);padding:14px 12px;font-size:13px;
-    text-transform:uppercase;letter-spacing:.06em;font-weight:700;
-  }
-  thead .sub{font-size:12px;text-transform:none;letter-spacing:0;color:#aab3c9}
-  tbody td{padding:12px;border-bottom:1px dashed #20283a;font-size:14.5px;color:#dfe6f7}
-  tbody tr:nth-child(odd){background:rgba(255,255,255,0.01)}
-  tbody tr:hover{background:#fff}
-  .time{
-    position:sticky;left:0;background:linear-gradient(90deg,#141821 70%,rgba(20,24,33,0));
-    z-index:2;font-weight:700;color:#c9d3ea;border-right:1px solid var(--line)
-  }
-  .status{
-    display:inline-flex;align-items:center;gap:8px;font-weight:650;padding:6px 10px;border-radius:999px;
-    background:#0f141e;border:1px solid #273045
-  }
-  .status.ok{color:#ccffe1;border-color:#1d3c2c;background:rgba(24,201,100,.10)}
-  .status.bad{color:#ffe1e1;border-color:#402126;background:rgba(255,77,79,.10)}
-  .status.warn{color:#fff5dc;border-color:#3d2d12;background:rgba(255,191,71,.12)}
-  .cond{color:#cdd6ee}
-  .mini{display:flex;gap:10px;align-items:center;color:var(--muted);font-size:12px}
-  .pill{padding:.2rem .55rem;border-radius:999px;border:1px solid var(--chip-br);color:#c9d3ea;background:#0f141e;font-size:12px}
-  .now{outline:2px solid var(--accent);outline-offset:-2px;background:#10182a !important}
+  thead th{position:sticky;top:0;z-index:3;background:var(--header-bg);color:var(--head-text);border-bottom:1px solid var(--line);padding:16px 14px;font-size:12.5px;text-transform:uppercase;letter-spacing:.08em;font-weight:600;transition:background .4s ease,color .4s ease,border-color .4s ease}
+  thead th.machine-head{padding-inline:18px 16px}
+  thead th.machine-head:not(:first-of-type){border-left:var(--divider)}
+  thead .sub{font-size:12px;text-transform:none;letter-spacing:0;color:var(--muted);margin-top:2px;font-weight:500}
+  tbody td{padding:16px 16px;border-bottom:1px solid var(--line);font-size:14.5px;color:var(--cell-text);vertical-align:top;transition:background .3s ease,color .3s ease,border-color .3s ease}
+  tbody td.machine-divider{border-left:var(--divider)}
+  tbody td.status-cell{text-align:center;width:90px}
+  tbody tr:nth-child(odd){background:var(--row-alt)}
+  tbody tr:hover{background:var(--row-hover)}
+  .time{position:sticky;left:0;background:var(--time-gradient,linear-gradient(90deg,var(--header-bg) 75%,rgba(255,255,255,0)));z-index:2;font-weight:600;color:var(--text);border-right:1px solid var(--line)}
+  .status-swatch{display:inline-flex;width:64px;height:22px;border-radius:999px;box-shadow:var(--status-shadow);background:var(--status-neutral-bg);border:1px solid var(--status-neutral-border)}
+  .status-swatch.ok{background:var(--status-ok-bg);border-color:var(--status-ok-border)}
+  .status-swatch.warn{background:var(--status-warn-bg);border-color:var(--status-warn-border)}
+  .status-swatch.bad{background:var(--status-bad-bg);border-color:var(--status-bad-border)}
+  .status-swatch.future{background:var(--status-future-bg);border-color:var(--status-future-border);box-shadow:none}
+  .cond{color:var(--cond-text);line-height:1.5}
+  .cond-tags{display:flex;flex-wrap:wrap;gap:6px}
+  .cond-chip{display:inline-flex;align-items:center;justify-content:center;min-width:42px;padding:6px 12px;border-radius:14px;font-size:11.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase}
+  .cond-chip.bad{background:var(--chip-bad-bg);border:1px solid var(--chip-bad-border);color:var(--chip-bad-text)}
+  .cond-chip.warn{background:var(--chip-warn-bg);border:1px solid var(--chip-warn-border);color:var(--chip-warn-text)}
+  .mini{display:flex;flex-wrap:wrap;gap:12px;align-items:center;color:var(--muted);font-size:12.5px;margin-top:20px}
+  .pill{padding:.35rem .8rem;border-radius:999px;border:var(--pill-border);color:var(--text);background:var(--pill-bg);font-size:12.5px;box-shadow:var(--pill-shadow)}
+  .now{box-shadow:inset 0 0 0 2px var(--now-outline);background:var(--now-bg)!important}
   @media (max-width: 900px){
+    header{flex-direction:column}
+    .controls{width:100%}
+    .controls .action-btn{flex:1;justify-content:center;text-align:center}
     thead .hide-sm, tbody .hide-sm{display:none}
     .subtitle{max-width:500px}
   }
 </style>
 </head>
-<body>
+<body class="theme-aurora">
   <div class="wrap">
     <header>
       <div class="title">
         <h1>Dashboard de Operación — 4 Máquinas</h1>
         <div class="subtitle">
-          Jornada: <strong>06:00</strong> a <strong>16:00</strong> · Intervalo cada <strong>15 min</strong>
+          Jornada: <strong>06:00</strong> a <strong>12:00</strong> · Intervalo cada <strong>15 min</strong>
           <div class="chips">
             <span class="chip"><span class="dot ok"></span> Estado positivo</span>
             <span class="chip"><span class="dot warn"></span> Aviso</span>
@@ -89,10 +244,31 @@
         </div>
       </div>
       <div class="controls">
-        <button id="regen">Generar nuevos datos</button>
-        <button id="scrollNow" class="ghost">Ir al bloque horario actual</button>
+        <button id="regen" class="action-btn">Generar nuevos datos</button>
+        <button id="scrollNow" class="action-btn ghost">Ir al bloque horario actual</button>
       </div>
     </header>
+
+    <section class="theme-explorer" aria-labelledby="themeTitle">
+      <div>
+        <h2 id="themeTitle">Explorar propuestas visuales</h2>
+        <p>Selecciona una propuesta para adaptar la tabla y sus columnas a diferentes estilos visuales. Cada modo ajusta colores, densidades, divisiones y textura general para ayudarte a elegir la dirección correcta.</p>
+      </div>
+      <div class="theme-picker" role="group" aria-label="Propuestas de diseño">
+        <button class="theme-btn active" data-theme="aurora">
+          <span class="theme-name">Aurora minimal</span>
+          <span class="theme-desc">Claridad blanca, divisores suaves y luz fría.</span>
+        </button>
+        <button class="theme-btn" data-theme="blueprint">
+          <span class="theme-name">Blueprint nocturno</span>
+          <span class="theme-desc">Estética técnica con fondo oscuro y neón.</span>
+        </button>
+        <button class="theme-btn" data-theme="atlas">
+          <span class="theme-name">Atlas cálido</span>
+          <span class="theme-desc">Paleta terrosa con líneas punteadas y textura.</span>
+        </button>
+      </div>
+    </section>
 
     <div class="panel">
       <table class="tbl" id="grid">
@@ -101,7 +277,7 @@
       </table>
     </div>
 
-    <div class="mini" style="margin-top:12px">
+    <div class="mini">
       <span class="pill" id="summary-ok">OK: —</span>
       <span class="pill" id="summary-warn">Avisos: —</span>
       <span class="pill" id="summary-bad">Fallas: —</span>
@@ -110,103 +286,130 @@
   </div>
 
 <script>
-(function(){
-  // ----- Configuración -----
+(()=>{
   const machines = [
-    { name: "Máquina 1" },
-    { name: "Máquina 2" },
-    { name: "Máquina 3" },
-    { name: "Máquina 4" },
+    {name:"Máquina A"},
+    {name:"Máquina B"},
+    {name:"Máquina C"},
+    {name:"Máquina D"}
   ];
 
-  // Condiciones base (en el mismo orden que tu hoja)
-  const FIELDS = [
-    "Gafete operador escaneado",
-    "Gafete de técnico escaneado",
-    "Carrete escaneado",
-    "Hoja de ruta escaneada",
-    "Cabezal en operación",
-    "Carrete en consumo",
-  ];
+  const FIELDS = {
+    temperatura:{label:"Temperatura",min:60,max:92},
+    vibracion:{label:"Vibración",max:8},
+    presion:{label:"Presión",min:40,max:68},
+    flujo:{label:"Flujo",min:120,max:200},
+    voltaje:{label:"Voltaje",min:210,max:240},
+    aceite:{label:"Nivel aceite",min:38,max:60},
+    seguridad:{label:"Seguridad",values:["OK","Candado"]},
+    energia:{label:"Energía",values:["Estable","Inestable"]}
+  };
 
-  // Qué se considera crítico para caer en ROJO si está en false
-  const CRITICAL = new Set([
-    "Carrete escaneado",
-    "Cabezal en operación",
-    "Carrete en consumo",
-  ]);
+  const CRITICAL = new Set(["temperatura","presion","voltaje","seguridad"]);
+  const WARN = new Set(["vibracion","flujo","aceite","energia"]);
 
-  const start = "06:00";
-  const end   = "16:00";
+  const FIELD_TAG = {
+    temperatura:"TEMP",
+    vibracion:"VIB",
+    presion:"PRES",
+    flujo:"FLU",
+    voltaje:"VLT",
+    aceite:"ACE",
+    seguridad:"SEG",
+    energia:"ENG"
+  };
+
+  const STATUS_LABELS = {
+    ok:"Estado óptimo",
+    warn:"Aviso de seguimiento",
+    bad:"Falla detectada",
+    future:"Pendiente de registrar"
+  };
+
   const stepMinutes = 15;
+  const start = "06:00";
+  const end = "12:00";
 
-  // Probabilidades base (afinables)
-  const P = {
-    badgeOperador: 0.96,
-    badgeTecnico : 0.94,
-    carreteScan  : 0.93,
-    hojaRuta     : 0.91,
-    operacion    : 0.82,
-    consumoSiOperando: 0.93, // si opera, prob de consumo true
-    consumoSiNoOpera : 0.10, // si no opera, casi siempre false
-  };
-
-  // ----- Utilidades -----
-  const toMinutes = (hhmm)=> {
+  function toMinutes(hhmm){
     const [h,m] = hhmm.split(":").map(Number);
-    return h*60+m;
-  };
-  const pad = (n)=> (n<10?"0":"")+n;
-  const fmt = (mins)=> `${pad(Math.floor(mins/60))}:${pad(mins%60)}`;
-  const buildSlots = (a,b,step)=>{const out=[],A=toMinutes(a),B=toMinutes(b);for(let t=A;t<=B;t+=step) out.push(fmt(t));return out;};
-  const chance = (p)=> Math.random()<p;
-
-  // Registra un diccionario de T/F por campo con correlaciones realistas
-  function crearRegistroTF(){
-    const tf = {};
-    tf[FIELDS[0]] = chance(P.badgeOperador);
-    tf[FIELDS[1]] = chance(P.badgeTecnico);
-    tf[FIELDS[2]] = chance(P.carreteScan);
-    tf[FIELDS[3]] = chance(P.hojaRuta);
-    tf[FIELDS[4]] = chance(P.operacion);
-    // Consumo depende de si está operando
-    tf[FIELDS[5]] = tf[FIELDS[4]] ? chance(P.consumoSiOperando) : chance(P.consumoSiNoOpera);
-    return tf;
+    return h*60 + m;
   }
 
-  // Evalúa: verde/amarillo/rojo + mensaje
-  function evaluarRegistro(tf){
+  function pad(num){
+    return String(num).padStart(2,"0");
+  }
+
+  function buildSlots(start,end,step){
+    const slots = [];
+    let cursor = toMinutes(start);
+    const endMinutes = toMinutes(end);
+    while(cursor <= endMinutes){
+      const h = Math.floor(cursor/60);
+      const m = cursor % 60;
+      slots.push(`${pad(h)}:${pad(m)}`);
+      cursor += step;
+    }
+    return slots;
+  }
+
+  function rand(min,max){
+    return Math.random()*(max-min)+min;
+  }
+
+  function pick(arr){
+    return arr[Math.floor(Math.random()*arr.length)];
+  }
+
+  function crearRegistroTF(){
+    return {
+      temperatura:Math.round(rand(55,102)),
+      vibracion:+rand(2,12).toFixed(1),
+      presion:Math.round(rand(30,80)),
+      flujo:Math.round(rand(90,240)),
+      voltaje:Math.round(rand(190,252)),
+      aceite:Math.round(rand(20,72)),
+      seguridad:pick(["OK","OK","OK","Candado"]),
+      energia:pick(["Estable","Estable","Inestable"])
+    };
+  }
+
+  function evaluarRegistro(registro){
     const errores = [];
     const avisos = [];
-    for(const k of FIELDS){
-      if(!tf[k]){
-        if(CRITICAL.has(k)) errores.push(`Error: ${k}`);
-        else avisos.push(`Aviso: ${k}`);
+
+    for(const k of Object.keys(registro)){
+      if(CRITICAL.has(k)){
+        const bounds = FIELDS[k];
+        if(bounds.min!==undefined && registro[k] < bounds.min) errores.push(k);
+        else if(bounds.max!==undefined && registro[k] > bounds.max) errores.push(k);
+        else if(bounds.values && !bounds.values.includes(registro[k])) errores.push(k);
+      } else if(WARN.has(k)){
+        const bounds = FIELDS[k];
+        if(bounds.min!==undefined && registro[k] < bounds.min) avisos.push(k);
+        else if(bounds.max!==undefined && registro[k] > bounds.max) avisos.push(k);
+        else if(bounds.values && !bounds.values.includes(registro[k])) avisos.push(k);
       }
     }
     if(errores.length===0 && avisos.length===0){
-      return {class:"ok", label:"Activo", msg:"Todo en orden"};
+      return {class:"ok", errores, avisos};
     }
     if(errores.length>0){
-      return {class:"bad", label:"Falla", msg:[...errores, ...avisos].join(", ")};
+      return {class:"bad", errores, avisos};
     }
-    // solo avisos (faltantes no críticos)
-    return {class:"warn", label:"En espera", msg:avisos.join(", ")};
+    return {class:"warn", errores, avisos};
   }
 
-  // ----- Render de cabecera -----
   function renderHead(){
     const thead = document.getElementById("thead");
     const tr1 = document.createElement("tr");
     tr1.innerHTML = `
       <th style="left:0;z-index:4" class="time">Horario</th>
-      ${machines.map(m=>`<th colspan="2">${m.name}<div class="sub">Status · Condición (según reglas)</div></th>`).join("")}
+      ${machines.map(m=>`<th class="machine-head" colspan="2">${m.name}<div class="sub">Status · Condición (según reglas)</div></th>`).join("")}
     `;
     thead.innerHTML = "";
     thead.appendChild(tr1);
   }
 
-  // ----- Generación y render de datos -----
   function generateData(){
     const slots = buildSlots(start,end,stepMinutes);
 
@@ -221,36 +424,49 @@
     for(const hhmm of slots){
       const tr = document.createElement("tr");
 
-      // Columna horario
       const tdTime = document.createElement("td");
       tdTime.textContent = hhmm;
       tdTime.className = "time";
       tr.appendChild(tdTime);
 
-      // Por cada máquina: evaluar condiciones -> estado + detalle
-      machines.forEach(()=> {
-        const tf = crearRegistroTF();
-        const ev = evaluarRegistro(tf);
+      const rowMins = toMinutes(hhmm);
+      const isFuture = rowMins > currentMinutes;
 
+      machines.forEach((_, idx)=> {
         const tdStatus = document.createElement("td");
-        tdStatus.innerHTML = `<span class="status ${ev.class}">
-            <span class="dot ${ev.class}"></span>${ev.label}
-          </span>`;
-
+        tdStatus.className = "status-cell";
         const tdCond = document.createElement("td");
         tdCond.className = "cond";
-        tdCond.innerHTML = (ev.class==="ok")
-          ? `<span class="dot warn" style="margin-right:8px;opacity:.5"></span>Todo en orden`
-          : `<span class="dot ${ev.class==='bad'?'bad':'warn'}" style="margin-right:8px"></span>${ev.msg}`;
+
+        if(idx>0){
+          tdStatus.classList.add("machine-divider");
+        }
+
+        if(isFuture){
+          tdStatus.innerHTML = `<span class="status-swatch future" title="${STATUS_LABELS.future}" aria-label="${STATUS_LABELS.future}"></span>`;
+          tdCond.textContent = "";
+        } else {
+          const tf = crearRegistroTF();
+          const ev = evaluarRegistro(tf);
+          tdStatus.innerHTML = `<span class="status-swatch ${ev.class}" title="${STATUS_LABELS[ev.class]}" aria-label="${STATUS_LABELS[ev.class]}"></span>`;
+
+          if(ev.class === "ok"){
+            tdCond.textContent = "";
+            cOK++;
+          } else {
+            const chips = [
+              ...ev.errores.map(field => `<span class="cond-chip bad">${FIELD_TAG[field]||field}</span>`),
+              ...ev.avisos.map(field => `<span class="cond-chip warn">${FIELD_TAG[field]||field}</span>`)
+            ].join("");
+            tdCond.innerHTML = `<div class="cond-tags">${chips}</div>`;
+            if(ev.class === "warn") cWARN++; else cBAD++;
+          }
+        }
 
         tr.appendChild(tdStatus);
         tr.appendChild(tdCond);
-
-        if(ev.class==="ok") cOK++; else if(ev.class==="warn") cWARN++; else cBAD++;
       });
 
-      // Resalta el bloque horario actual si cae dentro del intervalo
-      const rowMins = toMinutes(hhmm);
       if (rowMins <= currentMinutes && currentMinutes < rowMins + stepMinutes){
         tr.classList.add("now");
         tr.id = "nowRow";
@@ -259,7 +475,6 @@
       tbody.appendChild(tr);
     }
 
-    // Resumen
     const total = cOK + cWARN + cBAD;
     const disponibilidad = total ? Math.round((cOK/total)*100) : 0;
     document.getElementById("summary-ok").textContent   = `OK: ${cOK}`;
@@ -268,7 +483,6 @@
     document.getElementById("summary-rate").textContent = `Disponibilidad: ${disponibilidad}%`;
   }
 
-  // ----- Acciones -----
   function scrollToNow(){
     const el = document.getElementById("nowRow");
     if(!el){ window.scrollTo({top:0,behavior:"smooth"}); return; }
@@ -277,9 +491,50 @@
     el.animate([{outlineColor:"transparent"}, {outlineColor:"var(--accent)"}], {duration:600,iterations:1});
   }
 
-  // Init
+  function setupThemes(){
+    const THEME_KEY = "dashboard-tempo-theme";
+    const buttons = Array.from(document.querySelectorAll('.theme-btn[data-theme]'));
+    const body = document.body;
+    const apply = theme => {
+      const classList = ["theme-aurora","theme-blueprint","theme-atlas"];
+      classList.forEach(cls => body.classList.remove(cls));
+      const targetClass = `theme-${theme}`;
+      body.classList.add(targetClass);
+      buttons.forEach(btn => {
+        const isActive = btn.dataset.theme === theme;
+        btn.classList.toggle("active", isActive);
+        btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
+      try {
+        localStorage.setItem(THEME_KEY, theme);
+      } catch (err) {
+        /* almacenamiento no disponible */
+      }
+    };
+
+    let stored = null;
+    try {
+      stored = localStorage.getItem(THEME_KEY);
+    } catch (err) {
+      stored = null;
+    }
+    const initial = stored && ["aurora","blueprint","atlas"].includes(stored) ? stored : "aurora";
+    apply(initial);
+
+    buttons.forEach(btn => {
+      btn.addEventListener("click", () => apply(btn.dataset.theme));
+      btn.addEventListener("keyup", evt => {
+        if(evt.key === "Enter" || evt.key === " "){
+          evt.preventDefault();
+          apply(btn.dataset.theme);
+        }
+      });
+    });
+  }
+
   renderHead();
   generateData();
+  setupThemes();
   document.getElementById("regen").addEventListener("click", generateData);
   document.getElementById("scrollNow").addEventListener("click", scrollToNow);
 })();


### PR DESCRIPTION
## Summary
- add a proposal selector so the dashboard can switch between three themed visual treatments
- refactor styling to use theme variables and update controls to preview distinct column separation layouts

## Testing
- not run (static HTML)

------
https://chatgpt.com/codex/tasks/task_e_68e3d5cd4c388323a90fa5961c0172c8