### PR TITLE
Restaurar interfaz previa de Control EPP y reestablecer sección de registro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,23 @@
-# Plantilla de Dashboard de Producción
+# Control EPP (plantilla web)
 
-Esta plantilla proporciona una base modular para construir tableros de monitoreo de líneas de producción. Separa la lógica en
-archivos independientes de HTML, CSS y JavaScript para facilitar la personalización y la extensión en proyectos futuros.
+Este proyecto ahora incluye una interfaz web inspirada en la imagen de referencia para gestionar:
 
-## Estructura del proyecto
+- Búsqueda de trabajadores por **RPE, departamento y puesto**.
+- Checklist de **EPP por departamento/puesto**.
+- Carga, visualización, descarga y eliminación de **documentos PDF** por trabajador y EPP.
+- Carga de imagen de empresa y foto de trabajador.
 
-```
+## Persistencia de datos
 
-public/
->>>>>>> origin/main
-├── assets/
-│   ├── css/
-│   │   └── main.css
-│   └── js/
-│       ├── app.js
-│       ├── data.js
-│       ├── logic.js
-│       └── render.js
-<<<<<<< HEAD
-├── index.html
-└── README.md
-=======
-└── index.html
+La demo usa **IndexedDB** (base de datos del navegador) con los almacenes:
 
-```
+- `trabajadores`
+- `controlEpp`
+- `documentos`
+- `empresa`
 
-- **index.html**: Contiene la estructura del documento y enlaza los recursos de estilo y scripts.
-- **main.css**: Define la apariencia visual del tablero.
-- **data.js**: Centraliza constantes, estado inicial y variables compartidas.
-- **logic.js**: Incluye funciones de negocio para generar datos, aplicar reglas y gestionar el estado.
-- **render.js**: Responsable de la actualización de la interfaz y del renderizado de componentes.
-- **app.js**: Punto de entrada que inicializa el tablero y conecta eventos de usuario.
+Además, se incluye un esquema SQL sugerido para backend en `database/schema.sql`.
 
-## Uso local
+## Ejecutar local
 
-
-1. Abre `index.html` en tu navegador preferido.
-2. Personaliza los archivos dentro de `assets/` para ajustar estilos, reglas de negocio o textos según tus necesidades.
-=======
-1. Abre `public/index.html` en tu navegador preferido.
-2. Personaliza los archivos dentro de `public/assets/` para ajustar estilos, reglas de negocio o textos según tus necesidades.
-
-
-## Personalización sugerida
-
-- Ajusta los nombres de máquinas y los indicadores en `data.js`.
-- Modifica las reglas de severidad o los cálculos de KPIs en `logic.js`.
-- Cambia la distribución de tarjetas o componentes visuales en `render.js` y `main.css`.
-
-Con esta estructura modular, puedes ampliar fácilmente el panel para nuevas métricas, fuentes de datos o estilos corporativos.
+Puedes abrir `index.html` directamente en el navegador.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,319 +1,76 @@
 :root {
-  --bg: #fff;
-  --ink: #1a1f2b;
-  --muted: #667085;
-  --line: #e7e9ee;
-  --card: #f7f8fb;
-  --ok: #16a34a;
-  --warn: #f59e0b;
-  --bad: #ef4444;
-  --info: #2563eb;
-  --radius: 16px;
+  --green-100: #e4f2e7;
+  --green-200: #d1e6d6;
+  --green-500: #198754;
+  --green-700: #0f6b42;
+  --gray-100: #f8f9fa;
+  --gray-300: #d6d9dd;
 }
 
-* {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  height: 100%;
-}
-
+* { box-sizing: border-box; }
 body {
   margin: 0;
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, Roboto, Helvetica, Arial;
-  color: var(--ink);
-  background: var(--bg);
-}
-
-.wrap {
-  max-width: none;
-  margin: 0 auto;
-  padding: 12px 16px;
+  font-family: Arial, sans-serif;
+  background: var(--green-100);
+  color: #102027;
 }
 
 .topbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
-}
-
-.legend {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
   background: #fff;
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 99px;
-}
-
-.dot.ok {
-  background: var(--ok);
-}
-
-.dot.warn {
-  background: var(--warn);
-}
-
-.dot.bad {
-  background: var(--bad);
-}
-
-.dot.info {
-  background: var(--info);
-}
-
-.btn {
-  appearance: none;
-  border: 1px solid #cfe0ff;
-  background: #e9f2ff;
-  border-radius: 10px;
-  padding: 8px 12px;
-  font-size: 14px;
-  cursor: pointer;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: 55fr 45fr;
-  gap: 12px;
-  align-items: start;
-}
-
-@media (max-width: 1200px) {
-  .grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.timeline-bare {
-  height: calc(100vh - 80px);
-  overflow: auto;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-th,
-td {
-  border-bottom: 1px solid var(--line);
-  padding: 10px;
-  text-align: center;
-  font-size: 13px;
-  vertical-align: middle;
-}
-
-thead th {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  z-index: 1;
-}
-
-td.time {
-  font-weight: 600;
-  text-align: left;
-}
-
-tr.current {
-  background: #f0f7ff;
-}
-
-tr.current td {
-  border-bottom-color: #cfe0ff;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 108px;
-  height: 36px;
-  border-radius: 999px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-}
-
-.chip.ok {
-  background: var(--ok);
-}
-
-.chip.warn {
-  background: var(--warn);
-}
-
-.chip.bad {
-  background: var(--bad);
-}
-
-.chip.future {
-  width: 86px;
-  height: 28px;
-  border-radius: 999px;
-  background: repeating-linear-gradient(135deg, #f8f9fc 0 8px, #e9edf7 8px 16px);
-  border: 1px dashed var(--line);
-}
-
-.chip .ico {
-  display: inline-flex;
-}
-
-.chip .ico svg {
-  width: 22px;
-  height: 22px;
-  fill: #fff;
-}
-
-.chip.ok,
-.chip.warn,
-.chip.bad {
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08) inset;
-}
-
-.right-col {
+  border-bottom: 1px solid var(--gray-300);
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  height: calc(100vh - 80px);
-  overflow: auto;
+  align-items: center;
+  padding: 16px 24px;
+  gap: 28px;
 }
+.brand { font-size: 33px; font-weight: 700; }
+.topbar nav a { margin-right: 18px; color: #2f3d4a; text-decoration: none; }
 
-.right-col h2 {
-  margin: 0 0 4px 0;
-  font-size: 18px;
-}
-
-.right-col .description {
-  margin: 0 0 16px 0;
-  color: var(--muted);
-  font-size: 14px;
-}
-
-.machines {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.machine {
-  background: var(--card);
-  border: 1px solid var(--line);
+.layout { padding: 24px; display: grid; gap: 18px; }
+.panel {
+  background: var(--green-200);
+  border: 1px solid #b6d1bc;
   border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  padding: 18px;
 }
+.panel-title-row { display: flex; justify-content: space-between; align-items: center; }
 
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.header strong {
-  font-size: 20px;
-}
-
-.state {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.badge {
-  font-size: 14px;
-  padding: 4px 8px;
-  border-radius: 999px;
-  border: 1px solid #e2e8f0;
-  background: #fff;
-}
-
-.rows {
+.search-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(4, minmax(160px, 1fr));
   gap: 12px;
+  margin: 16px 0;
 }
-
-.row {
+label { display: grid; gap: 6px; font-size: 14px; }
+input[type="text"], input[type="file"] {
+  padding: 8px;
+  border: 1px solid #b2bcc5;
+  border-radius: 6px;
+}
+.btn {
+  border: 1px solid #7b8a98;
   background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 14px;
-  font-size: 14px;
-  line-height: 1.2;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  border-radius: 7px;
+  cursor: pointer;
+  padding: 10px 14px;
 }
+.btn-green { background: var(--green-500); color: #fff; border-color: var(--green-700); }
 
-.oval {
-  width: 28px;
-  height: 16px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-}
+.table-wrap { overflow: auto; background: #fff; border-radius: 8px; border: 1px solid var(--gray-300); }
+table { width: 100%; border-collapse: collapse; min-width: 1200px; }
+th, td { border: 1px solid var(--gray-300); padding: 10px; vertical-align: top; }
+th { background: #eef1f4; text-align: left; }
 
-.oval.ok {
-  background: var(--ok);
-  border-color: var(--ok);
-}
+.worker-photo { width: 120px; height: 140px; object-fit: cover; border-radius: 8px; }
+.checklist-item { display: flex; gap: 8px; margin: 6px 0; }
+.epp-add { display: flex; gap: 8px; margin-top: 8px; }
+.epp-doc-row { display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; padding: 6px 0; border-bottom: 1px solid #e6eaee; }
+.doc-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+.badge { background: var(--green-500); color: #fff; border-radius: 999px; padding: 2px 8px; font-size: 12px; }
 
-.oval.bad {
-  background: var(--bad);
-  border-color: var(--bad);
-}
+.company-box { background: #fff; border: 1px solid var(--gray-300); border-radius: 8px; padding: 12px; }
+.company-upload { display: flex; gap: 8px; align-items: center; }
+.company-preview { margin-top: 8px; max-height: 100px; display: none; }
 
-.kpis {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-}
-
-.k {
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 10px;
-}
-
-.k .label {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.k .val {
-  font-weight: 600;
-  margin-top: 4px;
-}
-
-@media (max-width: 1400px) {
-  .machines {
-    grid-template-columns: 1fr;
-  }
-
-  .rows {
-    grid-template-columns: 1fr;
-  }
-}
+.form-grid { display: grid; grid-template-columns: repeat(3, minmax(180px, 1fr)); gap: 12px; align-items: end; }
+.muted { color: #526070; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,50 +1,231 @@
-import {
-  BLOCK_MIN,
-  machinesState,
-  MACHINE_IDS,
-} from './data.js';
-import {
-  startOfBlock,
-  formatHourMinute,
-  regenerateWindowCache,
-  randomizeCurrent,
-  applyRescanRules,
-} from './logic.js';
-import { renderTimeline, resizePanels } from './render.js';
+const DB_NAME = 'control-epp-db';
+const DB_VERSION = 1;
+let db;
 
-document.addEventListener('DOMContentLoaded', () => {
-  const timelineBox = document.getElementById('timelineBox');
-  const rightCol = document.getElementById('rightCol');
-  const timelineTable = document.getElementById('timeline');
-  const summaryHost = document.getElementById('machines');
-  const generateButton = document.getElementById('btnGenerate');
+const $ = (id) => document.getElementById(id);
 
-  const render = () => renderTimeline(timelineTable, summaryHost);
+async function initDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = (event) => {
+      const dbase = event.target.result;
 
-  resizePanels(timelineBox, rightCol);
-  window.addEventListener('resize', () => resizePanels(timelineBox, rightCol));
-
-  regenerateWindowCache();
-  render();
-
-  let lastLabel = '';
-  setInterval(() => {
-    const currentLabel = `${formatHourMinute(startOfBlock(new Date()))} – ${BLOCK_MIN} min`;
-    if (currentLabel !== lastLabel) {
-      randomizeCurrent();
-      applyRescanRules();
-      regenerateWindowCache();
-      render();
-      lastLabel = currentLabel;
-    }
-  }, 10000);
-
-  generateButton.addEventListener('click', () => {
-    randomizeCurrent();
-    applyRescanRules();
-    regenerateWindowCache();
-    render();
+      if (!dbase.objectStoreNames.contains('trabajadores')) {
+        const store = dbase.createObjectStore('trabajadores', { keyPath: 'rpe' });
+        store.createIndex('departamento', 'departamento', { unique: false });
+        store.createIndex('puesto', 'puesto', { unique: false });
+      }
+      if (!dbase.objectStoreNames.contains('controlEpp')) {
+        const store = dbase.createObjectStore('controlEpp', { keyPath: 'id', autoIncrement: true });
+        store.createIndex('deptRole', 'deptRole', { unique: false });
+      }
+      if (!dbase.objectStoreNames.contains('documentos')) {
+        const store = dbase.createObjectStore('documentos', { keyPath: 'id', autoIncrement: true });
+        store.createIndex('workerEpp', 'workerEpp', { unique: false });
+      }
+      if (!dbase.objectStoreNames.contains('empresa')) {
+        dbase.createObjectStore('empresa', { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
   });
-});
+}
 
-export { machinesState, MACHINE_IDS };
+function tx(store, mode = 'readonly') {
+  return db.transaction(store, mode).objectStore(store);
+}
+
+function getAll(store) {
+  return new Promise((resolve, reject) => {
+    const req = tx(store).getAll();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function save(store, data) {
+  return new Promise((resolve, reject) => {
+    const req = tx(store, 'readwrite').put(data);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function remove(store, id) {
+  return new Promise((resolve, reject) => {
+    const req = tx(store, 'readwrite').delete(id);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function fileToBase64(file) {
+  return new Promise((resolve) => {
+    if (!file) return resolve('');
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.readAsDataURL(file);
+  });
+}
+
+async function loadCompanyImage() {
+  const req = tx('empresa').get('logo');
+  req.onsuccess = () => {
+    const logo = req.result?.image;
+    const preview = $('companyPreview');
+    if (logo) {
+      preview.src = logo;
+      preview.style.display = 'block';
+    }
+  };
+}
+
+async function renderWorkers() {
+  const workers = await getAll('trabajadores');
+  const epps = await getAll('controlEpp');
+  const docs = await getAll('documentos');
+
+  const filters = {
+    rpe: $('searchRpe').value.toLowerCase(),
+    dept: $('searchDept').value.toLowerCase(),
+    role: $('searchRole').value.toLowerCase()
+  };
+
+  const filtered = workers.filter((w) =>
+    w.rpe.toLowerCase().includes(filters.rpe) &&
+    w.departamento.toLowerCase().includes(filters.dept) &&
+    w.puesto.toLowerCase().includes(filters.role)
+  );
+
+  $('workersBody').innerHTML = filtered.map((w) => {
+    const key = `${w.departamento}::${w.puesto}`;
+    const workerEpps = epps.filter((e) => e.deptRole === key);
+    const checklistHtml = workerEpps.map((e) => `<label class="checklist-item"><input type="checkbox" checked disabled />${e.nombre}</label>`).join('');
+    const docsHtml = workerEpps.map((epp) => {
+      const doc = docs.find((d) => d.workerEpp === `${w.rpe}::${epp.id}`);
+      const hasDoc = Boolean(doc);
+      return `
+        <div class="epp-doc-row">
+          <div>
+            <strong>${epp.nombre}</strong>
+            <span class="badge">${hasDoc ? 'Cargado' : 'Pendiente'}</span>
+          </div>
+          <div class="doc-actions">
+            ${hasDoc ? `<a class="btn" href="${doc.file}" target="_blank">Ver PDF</a><a class="btn" href="${doc.file}" download="${doc.fileName}">Descargar</a><button class="btn" data-delete-doc="${doc.id}">Eliminar</button>` : ''}
+            <input type="file" accept="application/pdf" data-file="${w.rpe}:${epp.id}" />
+            <button class="btn btn-green" data-upload="${w.rpe}:${epp.id}">Subir</button>
+          </div>
+        </div>`;
+    }).join('');
+
+    return `<tr>
+      <td>${w.rpe}</td>
+      <td>${w.imagen ? `<img class="worker-photo" src="${w.imagen}" alt="${w.nombre}" />` : ''}</td>
+      <td>${w.nombre}</td>
+      <td>${w.departamento}</td>
+      <td>${w.puesto}</td>
+      <td>
+        ${checklistHtml}
+        <div class="epp-add">
+          <input type="text" placeholder="Nuevo EPP" data-epp-name="${w.rpe}" />
+          <button class="btn" data-add-epp="${w.rpe}">Agregar</button>
+        </div>
+      </td>
+      <td>${docsHtml || '<em>Sin EPP para este departamento/puesto</em>'}</td>
+    </tr>`;
+  }).join('');
+}
+
+async function bindActions() {
+  $('workerForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const imagen = await fileToBase64(form.get('imagen'));
+    await save('trabajadores', {
+      rpe: String(form.get('rpe')).trim(),
+      nombre: String(form.get('nombre')).trim(),
+      departamento: String(form.get('departamento')).trim(),
+      puesto: String(form.get('puesto')).trim(),
+      imagen
+    });
+    event.currentTarget.reset();
+    await renderWorkers();
+  });
+
+  $('saveCompanyImage').addEventListener('click', async () => {
+    const file = $('companyImage').files[0];
+    if (!file) return;
+    const image = await fileToBase64(file);
+    await save('empresa', { id: 'logo', image });
+    await loadCompanyImage();
+  });
+
+  $('searchBtn').addEventListener('click', renderWorkers);
+  ['searchRpe', 'searchDept', 'searchRole'].forEach((id) => $(id).addEventListener('input', renderWorkers));
+
+  document.body.addEventListener('click', async (event) => {
+    const addBtn = event.target.closest('[data-add-epp]');
+    if (addBtn) {
+      const rpe = addBtn.dataset.addEpp;
+      const workers = await getAll('trabajadores');
+      const worker = workers.find((w) => w.rpe === rpe);
+      const input = document.querySelector(`[data-epp-name="${rpe}"]`);
+      const nombre = input.value.trim();
+      if (!nombre || !worker) return;
+      await save('controlEpp', { nombre, deptRole: `${worker.departamento}::${worker.puesto}` });
+      input.value = '';
+      await renderWorkers();
+      return;
+    }
+
+    const uploadBtn = event.target.closest('[data-upload]');
+    if (uploadBtn) {
+      const [rpe, eppId] = uploadBtn.dataset.upload.split(':');
+      const fileInput = document.querySelector(`input[data-file="${rpe}:${eppId}"]`);
+      const file = fileInput.files[0];
+      if (!file) return;
+      const base64 = await fileToBase64(file);
+      const docs = await getAll('documentos');
+      const current = docs.find((d) => d.workerEpp === `${rpe}::${eppId}`);
+      await save('documentos', {
+        id: current?.id,
+        workerEpp: `${rpe}::${eppId}`,
+        file: base64,
+        fileName: file.name
+      });
+      await renderWorkers();
+      return;
+    }
+
+    const deleteBtn = event.target.closest('[data-delete-doc]');
+    if (deleteBtn) {
+      await remove('documentos', Number(deleteBtn.dataset.deleteDoc));
+      await renderWorkers();
+    }
+  });
+
+  $('downloadZip').addEventListener('click', async () => {
+    const payload = {
+      trabajadores: await getAll('trabajadores'),
+      controlEpp: await getAll('controlEpp'),
+      documentos: await getAll('documentos')
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'control-epp-export.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+}
+
+async function init() {
+  db = await initDb();
+  await bindActions();
+  await loadCompanyImage();
+  await renderWorkers();
+}
+
+init();

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,29 @@
+-- Esquema sugerido para implementación en backend (Razor + SQL Server/MySQL)
+
+CREATE TABLE DatosTrabajador (
+  RPE VARCHAR(20) PRIMARY KEY,
+  Nombre VARCHAR(120) NOT NULL,
+  ImagenTrabajador TEXT NULL,
+  Departamento VARCHAR(100) NOT NULL,
+  Puesto VARCHAR(100) NOT NULL,
+  FechaAlta DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE ControlEpp (
+  Id INT PRIMARY KEY AUTO_INCREMENT,
+  Departamento VARCHAR(100) NOT NULL,
+  Puesto VARCHAR(100) NOT NULL,
+  EppNombre VARCHAR(120) NOT NULL,
+  UNIQUE KEY uq_control_epp (Departamento, Puesto, EppNombre)
+);
+
+CREATE TABLE Documentos (
+  Id INT PRIMARY KEY AUTO_INCREMENT,
+  RPE VARCHAR(20) NOT NULL,
+  ControlEppId INT NOT NULL,
+  ArchivoNombre VARCHAR(260) NOT NULL,
+  ArchivoRuta TEXT NOT NULL,
+  FechaCarga DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (RPE) REFERENCES DatosTrabajador(RPE),
+  FOREIGN KEY (ControlEppId) REFERENCES ControlEpp(Id)
+);

--- a/index.html
+++ b/index.html
@@ -1,51 +1,84 @@
-wq<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="es">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Plantilla de Panel de Producción</title>
+    <title>Control EPP</title>
     <link rel="stylesheet" href="assets/css/main.css" />
   </head>
   <body>
-    <div class="wrap">
-      <header class="topbar">
-        <div class="legend">
-          <span class="pill"><span class="dot ok"></span>Estado positivo</span>
-          <span class="pill"><span class="dot warn"></span>Advertencia</span>
-          <span class="pill"><span class="dot bad"></span>Crítico</span>
-          <span class="pill"><span class="dot info"></span>Información</span>
-        </div>
-        <button id="btnGenerate" class="btn">Actualizar datos</button>
-      </header>
+    <header class="topbar">
+      <div class="brand">Control EPP</div>
+      <nav>
+        <a href="#busqueda">Buscar trabajador</a>
+        <a href="#registro">Registrar trabajador</a>
+      </nav>
+    </header>
 
-      <main class="grid">
-        <section class="timeline-bare" id="timelineBox">
-          <table id="timeline">
+    <main class="layout">
+      <section class="panel" id="busqueda">
+        <div class="panel-title-row">
+          <h1>Vista de EPP</h1>
+          <button id="downloadZip" class="btn btn-green">Exportar JSON</button>
+        </div>
+
+        <div class="search-grid">
+          <label>
+            RPE
+            <input id="searchRpe" type="text" placeholder="Ej. J408R" />
+          </label>
+          <label>
+            Departamento
+            <input id="searchDept" type="text" placeholder="Ej. Mantenimiento" />
+          </label>
+          <label>
+            Puesto
+            <input id="searchRole" type="text" placeholder="Ej. Técnico" />
+          </label>
+          <button id="searchBtn" class="btn">Buscar</button>
+        </div>
+
+        <div class="company-box">
+          <h3>Imagen de la empresa</h3>
+          <div class="company-upload">
+            <input id="companyImage" type="file" accept="image/*" />
+            <button id="saveCompanyImage" class="btn">Guardar imagen</button>
+          </div>
+          <img id="companyPreview" alt="Logo empresa" class="company-preview" />
+        </div>
+
+        <div class="table-wrap">
+          <table>
             <thead>
               <tr>
-                <th style="text-align:left">Horario</th>
-                <th>Máquina A</th>
-                <th>Máquina B</th>
-                <th>Máquina C</th>
-                <th>Máquina D</th>
+                <th>RPE</th>
+                <th>Imagen</th>
+                <th>Nombre</th>
+                <th>Departamento</th>
+                <th>Puesto</th>
+                <th>Checklist</th>
+                <th>Gestión de documentos (PDF)</th>
               </tr>
             </thead>
-            <tbody></tbody>
+            <tbody id="workersBody"></tbody>
           </table>
-        </section>
+        </div>
+      </section>
 
-        <aside class="right-col" id="rightCol">
-          <div>
-            <h2>Estado actual</h2>
-            <p class="description">
-              Este panel resume la actividad de cada estación y actúa como base para cualquier línea de producción. Ajusta los
-              textos, íconos y reglas según las necesidades de tu planta.
-            </p>
-            <div id="machines" class="machines"></div>
-          </div>
-        </aside>
-      </main>
-    </div>
+      <section class="panel" id="registro">
+        <h2>Registro / sincronización de trabajador</h2>
+        <p class="muted">La tabla queda lista para copiado desde otra base de datos. Puedes cargar registros de prueba.</p>
+
+        <form id="workerForm" class="form-grid">
+          <label>RPE <input required name="rpe" type="text" /></label>
+          <label>Nombre <input required name="nombre" type="text" /></label>
+          <label>Departamento <input required name="departamento" type="text" /></label>
+          <label>Puesto <input required name="puesto" type="text" /></label>
+          <label>Imagen del trabajador <input name="imagen" type="file" accept="image/*" /></label>
+          <button class="btn btn-green" type="submit">Guardar trabajador</button>
+        </form>
+      </section>
+    </main>
 
     <script type="module" src="assets/js/app.js"></script>
   </body>


### PR DESCRIPTION
### Motivation
- Restaurar la interfaz a la versión anterior para dejar la navegación con `Buscar trabajador` y `Registrar trabajador` y devolver la imagen de la empresa dentro del panel, tal como estaba antes del ajuste reciente. 
- Recuperar la sección de `Registro / sincronización de trabajador` y la lógica asociada para mantener la capacidad de cargas y gestión de EPP y documentos. 

### Description
- Restituye la estructura previa en `index.html`, reintroduciendo la barra superior con las opciones de navegación, el bloque de imagen de la empresa en el panel y el formulario `workerForm` con su `id`. 
- Restaura/ajusta estilos en `assets/css/main.css` para coincidir con el layout anterior (topbar, grid, paneles, previews y formulario). 
- Incluye la lógica de aplicación en `assets/js/app.js` basada en IndexedDB con funciones principales (`initDb`, `getAll`, `save`, `remove`, `fileToBase64`, `renderWorkers`, `bindActions`) y la llamada a `init()`. 
- Añade `database/schema.sql` y actualiza `README.md` para reflejar la funcionalidad actual del proyecto y la persistencia usada. 

### Testing
- Ejecuté la verificación de sintaxis con `node --check assets/js/app.js` y la comprobación pasó correctamente. 
- Levanté un servidor local con `python3 -m http.server 4173` y la página respondió correctamente en `http://127.0.0.1:4173`. 
- Automatización con Playwright abrió `http://127.0.0.1:4173` y generó una captura de pantalla de la interfaz restaurada satisfactoria. 
- No se detectaron errores de ejecución durante las pruebas automatizadas descritas anteriormente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b14139608323aa4ba31196ffa753)